### PR TITLE
fix character encoding in JDBC URL

### DIFF
--- a/allgemein/mysql-support.md
+++ b/allgemein/mysql-support.md
@@ -34,11 +34,11 @@ Damit JVerein auf eine MySQL/MariaDB-Datenbank zugreifen kann, muss eine Konfigu
 
 für MySQL:
 
-    database.driver.mysql.jdbcurl=jdbc:mysql://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=ISO8859_1
+    database.driver.mysql.jdbcurl=jdbc:mysql://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=UTF-8
 
 für MariaDB:
 
-    database.driver.mysql.jdbcurl=jdbc:mariadb://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=ISO8859_1
+    database.driver.mysql.jdbcurl=jdbc:mariadb://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=UTF-8
 
 für Jameica ab Version 2.11 (aktuell in Entwicklung)
 
@@ -50,7 +50,7 @@ Bei **Datenbanksystemen ohne Serverzertifikat** muss die Zertifikatsprüfung dea
 
 Beispiel für MySQL:
 
-    database.driver.mysql.jdbcurl=jdbc:mysql://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=ISO8859_1&trustServerCertificate=true&allowPublicKeyRetrieval=true&useSSL=false
+    database.driver.mysql.jdbcurl=jdbc:mysql://<ip>:<port>/<database>?useUnicode=Yes&characterEncoding=UTF-8&trustServerCertificate=true&allowPublicKeyRetrieval=true&useSSL=false
 
 ## Test und Verteilung der Konfiguration auf die Arbeitsplätze
 


### PR DESCRIPTION
Wenn die JVerein-Tabellen in MySQL/MariaDB initial erzeugt werden, wird kein character encoding angegeben. Somit wird das default charset verwendet, was meist `utf8mb4` ist. In der connection URL wird der Parameter `useUnicode=Yes` gesetzt und gleichzeitig das characterEncoding=ISO8859_1`. Dies widerspricht sich IMHO. Außerdem hat es den Nebeneffekt, dass Unicode-Zeichen wie z. B. EUR (€) oder Smilies (z. B.: 😀) nicht korrekt in der Datenbank gespeichert werden. Mit `characterEncoding=UTF-8` treten diese Probleme nicht auf.